### PR TITLE
feat(cli): deploy

### DIFF
--- a/apps/cli/assets/code/cfWorkerEntry.js
+++ b/apps/cli/assets/code/cfWorkerEntry.js
@@ -19,17 +19,20 @@ function createCloudflareAdapter(app) {
 		const { status, headers, body } = payload.serialized;
 		return new Response(JSON.stringify(body), {
 			status,
-			headers: Object.entries(headers).reduce((acc, [key, value]) => {
-				if (typeof value === 'string') {
-					acc[key] = value;
+			headers: (() => {
+				const headersObj = {
+					'content-type': 'application/json',
+				};
+				for (const [key, value] of Object.entries(headers)) {
+					if (typeof value === 'string') {
+						headersObj[key] = value;
+					}
+					if (Array.isArray(value)) {
+						headersObj[key] = value.join(',');
+					}
 				}
-
-				if (Array.isArray(value)) {
-					acc[key] = value.join(',');
-				}
-
-				return acc;
-			}),
+				return headersObj;
+			})(),
 		});
 	};
 }

--- a/apps/cli/src/commands/common/build.ts
+++ b/apps/cli/src/commands/common/build.ts
@@ -41,7 +41,7 @@ export async function BuildApp({
 	}
 
 	spinner = ora(
-		['Bundling project', `${color.gray('Target:')} ${color.magenta(overrideTarget || target)}`].join('\n'),
+		['Bundling project', `${color.gray('Target:')} ${color.magenta(overrideTarget?.type || target.type)}`].join('\n'),
 	).start();
 	const res = await Compile({ root, target: overrideTarget || target, entryFileName });
 	spinner.succeed();

--- a/apps/cli/src/commands/deploy.ts
+++ b/apps/cli/src/commands/deploy.ts
@@ -1,0 +1,53 @@
+import * as color from 'colorette';
+import ora from 'ora';
+import type { Argv, CommandModule } from 'yargs';
+import { ProjectTools } from '../lib/ProjectTools';
+import { UserError } from '../lib/UserError';
+import { WranglerWrapper } from '../lib/WranglerWrapper';
+import { logger } from '../utils/logger';
+import { BuildApp } from './common/build';
+
+export const aliases: string[] = [];
+export const desc: string = 'Build a project';
+
+export const builder = (yargs: Argv) => yargs.options({});
+
+export const DeployCommand: CommandModule = {
+	aliases,
+	builder,
+	command: 'deploy',
+	async handler() {
+		const conf = await ProjectTools.resolveProject({
+			cwd: process.cwd(),
+		});
+		const entry = await BuildApp({
+			skipPrebuild: true,
+		});
+
+		switch (conf.target.type) {
+			case 'cloudflare': {
+				const wrangler = new WranglerWrapper(conf, entry);
+
+				const spinner = ora('Deploying to Cloudflare Workers').start();
+
+				await wrangler.publish();
+
+				spinner.succeed('Deployed to Cloudflare Workers');
+
+				logger.info(
+					[
+						"You should visit the Cloudflare Workers dashboard to add your environment variables if you haven't already.",
+						`${color.gray('CLIENT_ID')} Your Discord application's client ID`,
+						`${color.gray('PUBLIC_KEY')} Your Discord application's public key`,
+						`${color.gray('TOKEN')} Your Discord application's bot token`,
+					].join('\n'),
+				);
+				break;
+			}
+
+			default: {
+				throw new UserError(`Unsupported deploy target type: ${conf.target.type}`);
+			}
+		}
+	},
+};

--- a/apps/cli/src/commands/dev.ts
+++ b/apps/cli/src/commands/dev.ts
@@ -37,7 +37,7 @@ export const DevCommand: CommandModule = {
 			const spinner = ora('Found change! Building project').start();
 			const entry = await BuildApp({
 				skipPrebuild: true,
-				overrideTarget: 'standalone',
+				overrideTarget: { type: 'standalone' },
 				entryFileName: `entry-${Math.random().toString(36).substring(7)}.mjs`,
 			});
 

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -40,7 +40,7 @@ export const SyncCommand: CommandModule = {
 
 		const entry = await BuildApp({
 			skipPrebuild: true,
-			overrideTarget: 'standalone',
+			overrideTarget: { type: 'standalone' },
 			entryFileName: `entry.mjs`,
 		});
 

--- a/apps/cli/src/disploy.ts
+++ b/apps/cli/src/disploy.ts
@@ -3,10 +3,11 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { BuildCommand } from './commands/build';
+import { DeployCommand } from './commands/deploy';
 import { DevCommand } from './commands/dev';
 import { SyncCommand } from './commands/sync';
 
-const commands = [SyncCommand, DevCommand, BuildCommand];
+const commands = [SyncCommand, DevCommand, BuildCommand, DeployCommand];
 
 const handler = yargs(hideBin(process.argv));
 

--- a/apps/cli/src/lib/WranglerWrapper.ts
+++ b/apps/cli/src/lib/WranglerWrapper.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+import type { DisployConfig } from './disployConf';
+import { UserError } from './UserError';
+
+export class WranglerWrapper {
+	constructor(private readonly config: DisployConfig, private readonly entryFilePath: string) {
+		try {
+			execSync('wrangler --version', { stdio: 'ignore' });
+		} catch (e) {
+			throw new UserError('Wrangler is not installed. Please install it with `npm install -g wrangler`.');
+		}
+	}
+
+	public async publish() {
+		if (this.config.target.type !== 'cloudflare') {
+			throw new UserError('This project is not configured to be deployed to Cloudflare Workers.');
+		}
+
+		execSync(
+			`wrangler publish ${this.entryFilePath} --compatibility-date 2022-11-05 --name ${this.config.target.name} --node-compat true`,
+			{ stdio: 'inherit' },
+		);
+	}
+}

--- a/apps/cli/src/lib/compiler/index.ts
+++ b/apps/cli/src/lib/compiler/index.ts
@@ -9,7 +9,7 @@ import { TempDir } from './constants';
 import { copyDir } from './copyDir';
 
 function parseTarget(target: DisployConfig['target']) {
-	switch (target) {
+	switch (target.type) {
 		case 'cloudflare':
 			return 'cfWorkerEntry';
 		case 'standalone':

--- a/apps/cli/src/lib/disployConf/index.ts
+++ b/apps/cli/src/lib/disployConf/index.ts
@@ -6,7 +6,15 @@ import { UserError } from '../UserError';
 const disployConfigSchema = z.object({
 	prebuild: z.string().optional(),
 	root: z.string(),
-	target: z.union([z.literal('cloudflare'), z.literal('standalone')]),
+	target: z.union([
+		z.object({
+			type: z.literal('cloudflare'),
+			name: z.string(),
+		}),
+		z.object({
+			type: z.literal('standalone'),
+		}),
+	]),
 });
 
 export type DisployConfig = z.infer<typeof disployConfigSchema>;

--- a/apps/example/disploy.json
+++ b/apps/example/disploy.json
@@ -1,5 +1,8 @@
 {
 	"prebuild": "yarn run build",
 	"root": "dist",
-	"target": "cloudflare"
+	"target": {
+		"type": "cloudflare",
+		"name": "cf-example"
+	}
 }


### PR DESCRIPTION
Implements a deploy command that supports Cloudflare workers.

Also refactors the `disploy.json` schema to support more options in the future, for now it just allows us to set a cf worker name.