### PR TITLE
fix(framework): non-nullable user

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -13,11 +13,12 @@
 		"serve": "disploy dev"
 	},
 	"dependencies": {
-		"@disploy/framework": "*"
+		"@disploy/framework": "*",
+		"discord-api-types": "^0.37.16"
 	},
 	"devDependencies": {
-		"disploy": "*",
 		"@types/node": "^18.11.3",
+		"disploy": "*",
 		"eslint": "7.32.0",
 		"eslint-config-custom": "*",
 		"tsconfig": "*",

--- a/apps/example/src/commands/channel.ts
+++ b/apps/example/src/commands/channel.ts
@@ -1,0 +1,47 @@
+import { Command, type ChatInputInteraction } from '@disploy/framework';
+import { ApplicationCommandOptionType, ChannelType } from 'discord-api-types/v10';
+export default class ChannelCommand extends Command {
+	public constructor() {
+		super({
+			name: 'channel',
+			description: 'fetch a channel!',
+			options: [
+				{
+					name: 'channel',
+					description: 'the channel id to fetch',
+					type: ApplicationCommandOptionType.String,
+					required: true,
+				},
+			],
+		});
+	}
+
+	override async slashRun(interaction: ChatInputInteraction) {
+		interaction.deferReply();
+
+		try {
+			const channelId = interaction.options.getString('channel');
+			const channel = await interaction.app.channels.fetch(channelId);
+
+			let message = `${channel.name} is `;
+
+			switch (channel.type) {
+				case ChannelType.GuildVoice:
+					message += 'a voice channel';
+					break;
+				case ChannelType.GuildText:
+					message += 'a text channel';
+					break;
+			}
+
+			return void interaction.editReply({
+				content: message,
+			});
+		} catch (error) {
+			const err = error as Error;
+			return void interaction.editReply({
+				content: ['```js', err.stack ?? err.message, '```'].join('\n'),
+			});
+		}
+	}
+}

--- a/apps/example/src/commands/hey.ts
+++ b/apps/example/src/commands/hey.ts
@@ -9,12 +9,16 @@ export default class HeyCommand extends Command {
 	}
 
 	override async slashRun(interaction: ChatInputInteraction) {
+		if (!interaction.guild) {
+			return interaction.reply({ content: 'You are not in a guild.' });
+		}
+
 		interaction.deferReply();
 
-		await new Promise((resolve) => setTimeout(resolve, 2000));
+		const guild = await interaction.guild.fetch();
 
 		return void interaction.editReply({
-			content: `Just wanted to say hey!`,
+			content: `Hello the people of ${guild.name}!`,
 		});
 	}
 }

--- a/apps/example/src/commands/me.ts
+++ b/apps/example/src/commands/me.ts
@@ -1,0 +1,32 @@
+import { Command, type ChatInputInteraction } from '@disploy/framework';
+
+export default class PingCommand extends Command {
+	public constructor() {
+		super({
+			name: 'me',
+			description: 'fetch me!',
+		});
+	}
+
+	override async slashRun(interaction: ChatInputInteraction) {
+		interaction.deferReply();
+
+		try {
+			const user = await interaction.app.user.fetch();
+
+			return void interaction.editReply({
+				embeds: [
+					{
+						title: 'User',
+						description: `**Username**: ${user.name}\n**Discriminator**: ${user.discriminator}\n**ID**: ${user.id}`,
+					},
+				],
+			});
+		} catch (error) {
+			const err = error as Error;
+			return void interaction.editReply({
+				content: ['```js', err.stack ?? err.message, '```'].join('\n'),
+			});
+		}
+	}
+}

--- a/packages/framework/src/client/App.ts
+++ b/packages/framework/src/client/App.ts
@@ -1,8 +1,9 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
+import { Routes } from 'discord-api-types/v10';
 import { Command, CommandManager } from '../commands';
 import { Router } from '../router';
-import { Guild, StructureManager, User } from '../structs';
-import { Channel } from '../structs/Channel';
+import { ChannelManager, Guild, StructureManager, User } from '../structs';
+import { ToBeFetched } from '../structs/ToBeFetched';
 import { Logger } from '../utils';
 import type { AppOptions } from './AppOptions';
 import { Rest } from './Rest';
@@ -19,7 +20,10 @@ export class App {
 	// Structure Managers
 	public users!: StructureManager<User>;
 	public guilds!: StructureManager<Guild>;
-	public channels!: StructureManager<Channel>;
+	public channels!: ChannelManager;
+
+	// Misc
+	public user!: ToBeFetched<User>;
 
 	private _commandBuffer: Command[] = [];
 
@@ -52,9 +56,12 @@ export class App {
 		this.router = new Router(this);
 
 		// Structure Managers
-		this.guilds = new StructureManager(this, Guild, (id) => this.rest.get(`/guilds/${id}`));
-		this.users = new StructureManager(this, User, (id) => this.rest.get(`/users/${id}`));
-		this.channels = new StructureManager(this, Channel, (id) => this.rest.get(`/channels/${id}`));
+		this.guilds = new StructureManager(this, Guild, (id) => this.rest.get(Routes.guild(id)));
+		this.users = new StructureManager(this, User, (id) => this.rest.get(Routes.user(id)));
+		this.channels = new ChannelManager(this);
+
+		// Misc
+		this.user = new ToBeFetched(this, User, () => this.rest.get(Routes.user(this.clientId)));
 
 		// Command Framework
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -4,4 +4,5 @@ export * from './commands';
 export * from './http';
 export * from './router';
 export * from './structs';
+export { DiscordChannel } from './types';
 export { RuntimeConstants, SnowflakeUtil } from './utils';

--- a/packages/framework/src/structs/BaseChannel.ts
+++ b/packages/framework/src/structs/BaseChannel.ts
@@ -1,9 +1,9 @@
-import type { APIChannel, Snowflake } from 'discord-api-types/v10';
+import { APIChannel, ChannelType, Routes, Snowflake } from 'discord-api-types/v10';
 import type { App } from '../client';
 import { SnowflakeUtil } from '../utils';
 import { Base } from './Base';
 
-export class Channel extends Base {
+export class BaseChannel extends Base {
 	/**
 	 * The ID of the channel.
 	 */
@@ -13,6 +13,11 @@ export class Channel extends Base {
 	 * Timestamp of when the channel was created.
 	 */
 	public createdTimestamp!: number;
+
+	/**
+	 * The type of the channel.
+	 */
+	public type!: ChannelType;
 
 	public constructor(app: App, raw: APIChannel) {
 		super(app);
@@ -24,7 +29,7 @@ export class Channel extends Base {
 	 * Deletes the channel.
 	 */
 	public async delete(): Promise<void> {
-		await this.app.rest.delete(`/channels/${this.id}`);
+		await this.app.rest.delete(Routes.channel(this.id));
 	}
 
 	/**
@@ -33,6 +38,6 @@ export class Channel extends Base {
 	 * @example interaction.reply(`You chose ${interaction.channel}`); // => You chose #general
 	 */
 	public override toString() {
-		return `<#${this.id}>`;
+		return this.id;
 	}
 }

--- a/packages/framework/src/structs/BaseInteraction.ts
+++ b/packages/framework/src/structs/BaseInteraction.ts
@@ -31,6 +31,6 @@ export class BaseInteraction extends Base {
 		this.id = raw.id;
 		this.token = raw.token;
 		this.createdTimestamp = SnowflakeUtil.toTimestamp(this.id);
-		this.guild = raw.guild_id ? new ToBeFetched(this, Guild, () => app.rest.get(`/guilds/${raw.guild_id}`)) : null;
+		this.guild = raw.guild_id ? new ToBeFetched(this.app, Guild, () => app.rest.get(`/guilds/${raw.guild_id}`)) : null;
 	}
 }

--- a/packages/framework/src/structs/BaseInteraction.ts
+++ b/packages/framework/src/structs/BaseInteraction.ts
@@ -2,6 +2,8 @@ import type { APIInteraction, Snowflake } from 'discord-api-types/v10';
 import type { App } from '../client';
 import { SnowflakeUtil } from '../utils';
 import { Base } from './Base';
+import { Guild } from './Guild';
+import { ToBeFetched } from './ToBeFetched';
 
 export class BaseInteraction extends Base {
 	/**
@@ -19,10 +21,16 @@ export class BaseInteraction extends Base {
 	 */
 	public token!: string;
 
+	/**
+	 * The guild of the interaction.
+	 */
+	public guild!: ToBeFetched<Guild> | null;
+
 	public constructor(app: App, raw: APIInteraction) {
 		super(app);
 		this.id = raw.id;
 		this.token = raw.token;
 		this.createdTimestamp = SnowflakeUtil.toTimestamp(this.id);
+		this.guild = raw.guild_id ? new ToBeFetched(this, Guild, () => app.rest.get(`/guilds/${raw.guild_id}`)) : null;
 	}
 }

--- a/packages/framework/src/structs/Guild.ts
+++ b/packages/framework/src/structs/Guild.ts
@@ -3,8 +3,7 @@ import type { App } from '../client';
 import { Base } from './Base';
 import { BaseChannel } from './BaseChannel';
 import { GuildBan } from './GuildBan';
-import type { ChannelManager } from './managers';
-import { StructureManager } from './managers';
+import { ChannelManager, StructureManager } from './managers';
 import { ToBeFetched } from './ToBeFetched';
 
 export class Guild extends Base {
@@ -72,7 +71,7 @@ export class Guild extends Base {
 
 	public constructor(app: App, raw: APIGuild) {
 		super(app);
-		this.channels = this.app.channels;
+		this.channels = new ChannelManager(app, this.id);
 		this.patch(raw);
 	}
 

--- a/packages/framework/src/structs/Guild.ts
+++ b/packages/framework/src/structs/Guild.ts
@@ -1,7 +1,10 @@
-import type { APIGuild, Snowflake } from 'discord-api-types/v10';
+import { APIGuild, Routes, Snowflake } from 'discord-api-types/v10';
 import type { App } from '../client';
 import { Base } from './Base';
-import { Channel } from './Channel';
+import { BaseChannel } from './BaseChannel';
+import { GuildBan } from './GuildBan';
+import type { ChannelManager } from './managers';
+import { StructureManager } from './managers';
 import { ToBeFetched } from './ToBeFetched';
 
 export class Guild extends Base {
@@ -23,7 +26,7 @@ export class Guild extends Base {
 	/**
 	 * The AFK channel of the guild.
 	 */
-	public afkChannel!: ToBeFetched<Channel> | null;
+	public afkChannel!: ToBeFetched<BaseChannel> | null;
 
 	/**
 	 * The AFK channel's ID of the guild.
@@ -35,16 +38,75 @@ export class Guild extends Base {
 	 */
 	public afkTimeout!: number;
 
+	/**
+	 * The ID of the application that owns the guild. (if it is a bot application)
+	 */
+	public applicationId!: Snowflake | null;
+
+	/**
+	 * The approximate number of members in the guild.
+	 * @warning You will need to use {@link Guild#fetch} to get this value.
+	 */
+	public approximateMemberCount?: number;
+
+	/**
+	 * The approximate number of presences in the guild.
+	 * @warning You will need to use {@link Guild#fetch} to get this value.
+	 */
+	public approximatePresenceCount?: number;
+
+	/**
+	 * The hash of the guild banner
+	 */
+	public banner!: string | null;
+
+	/**
+	 * The ban manager for this guild.
+	 */
+	public bans!: StructureManager<GuildBan>;
+
+	/**
+	 * Shortcut to {@link App#channels}
+	 */
+	public channels!: ChannelManager;
+
 	public constructor(app: App, raw: APIGuild) {
 		super(app);
+		this.channels = this.app.channels;
+		this.patch(raw);
+	}
+
+	private patch(raw: APIGuild): this {
 		this.id = raw.id;
 		this.ownerId = raw.owner_id;
 		this.name = raw.name;
 
 		this.afkChannel = raw.afk_channel_id
-			? new ToBeFetched(this, Channel, () => app.rest.get(`/channels/${raw.afk_channel_id}`))
+			? new ToBeFetched(this.app, BaseChannel, () => this.app.rest.get(`/channels/${raw.afk_channel_id}`))
 			: null;
 		this.afkChannelId = raw.afk_channel_id;
 		this.afkTimeout = raw.afk_timeout;
+		this.applicationId = raw.application_id;
+		this.banner = raw.banner;
+		this.bans = new StructureManager(this.app, GuildBan, async (id) => {
+			return {
+				guild: this,
+				raw: await this.app.rest.get(Routes.guildBan(this.id, id)),
+			};
+		});
+
+		if ('approximate_member_count' in raw) {
+			this.approximateMemberCount = raw.approximate_member_count;
+		}
+
+		if ('approximate_presence_count' in raw) {
+			this.approximatePresenceCount = raw.approximate_presence_count;
+		}
+
+		return this;
+	}
+
+	public async fetch(): Promise<this> {
+		return this.patch(await this.app.rest.get<APIGuild>(`/guilds/${this.id}?with_counts=true`));
 	}
 }

--- a/packages/framework/src/structs/Guild.ts
+++ b/packages/framework/src/structs/Guild.ts
@@ -1,6 +1,8 @@
 import type { APIGuild, Snowflake } from 'discord-api-types/v10';
 import type { App } from '../client';
 import { Base } from './Base';
+import { Channel } from './Channel';
+import { ToBeFetched } from './ToBeFetched';
 
 export class Guild extends Base {
 	/**
@@ -18,10 +20,31 @@ export class Guild extends Base {
 	 */
 	public name!: string;
 
+	/**
+	 * The AFK channel of the guild.
+	 */
+	public afkChannel!: ToBeFetched<Channel> | null;
+
+	/**
+	 * The AFK channel's ID of the guild.
+	 */
+	public afkChannelId!: Snowflake | null;
+
+	/**
+	 * The time in seconds a user has to be AFK before being moved to the AFK channel.
+	 */
+	public afkTimeout!: number;
+
 	public constructor(app: App, raw: APIGuild) {
 		super(app);
 		this.id = raw.id;
 		this.ownerId = raw.owner_id;
 		this.name = raw.name;
+
+		this.afkChannel = raw.afk_channel_id
+			? new ToBeFetched(this, Channel, () => app.rest.get(`/channels/${raw.afk_channel_id}`))
+			: null;
+		this.afkChannelId = raw.afk_channel_id;
+		this.afkTimeout = raw.afk_timeout;
 	}
 }

--- a/packages/framework/src/structs/GuildBan.ts
+++ b/packages/framework/src/structs/GuildBan.ts
@@ -1,0 +1,29 @@
+import type { APIBan } from 'discord-api-types/v10';
+import type { App } from '../client';
+import { Base } from './Base';
+import type { Guild } from './Guild';
+import { User } from './User';
+
+export class GuildBan extends Base {
+	/**
+	 * The guild this ban belongs to.
+	 */
+	public guild!: Guild;
+
+	/**
+	 * The user this ban belongs to.
+	 */
+	public user!: User;
+
+	/**
+	 * The reason for this ban.
+	 */
+	public reason!: string | null;
+
+	public constructor(app: App, { raw, guild }: { raw: APIBan; guild: Guild }) {
+		super(app);
+		this.guild = guild;
+		this.user = new User(app, raw.user);
+		this.reason = raw.reason;
+	}
+}

--- a/packages/framework/src/structs/GuildMember.ts
+++ b/packages/framework/src/structs/GuildMember.ts
@@ -7,7 +7,7 @@ export class GuildMember extends PartialGuildMember {
 	/**
 	 * The User object of the member.
 	 */
-	public user!: User | null;
+	public user!: User;
 
 	/**
 	 * Whether the user is deafened in voice channels
@@ -21,7 +21,7 @@ export class GuildMember extends PartialGuildMember {
 
 	public constructor(app: App, raw: APIGuildMember) {
 		super(app, raw);
-		this.user = raw.user ? new User(this.app, raw.user) : null;
+		this.user = new User(this.app, raw.user!);
 		this.deaf = raw.deaf ? Boolean(raw.deaf) : null;
 		this.mute = raw.mute ? Boolean(raw.mute) : null;
 	}

--- a/packages/framework/src/structs/GuildTextChannel.ts
+++ b/packages/framework/src/structs/GuildTextChannel.ts
@@ -1,0 +1,36 @@
+import { APIGuildChannel, ChannelType, Snowflake } from 'discord-api-types/v10';
+import type { App } from '../client';
+import { BaseChannel } from './BaseChannel';
+
+export class GuildTextChannel extends BaseChannel {
+	/**
+	 * The ID of the guild.
+	 */
+	public guildId!: Snowflake;
+
+	/**
+	 * The name of the channel.
+	 */
+	public name!: string;
+
+	/**
+	 * The type of the channel.
+	 */
+	public declare type: ChannelType.GuildText;
+
+	public constructor(app: App, raw: APIGuildChannel<ChannelType.GuildText>) {
+		super(app, raw);
+		this.guildId = raw.guild_id!;
+		this.name = raw.name!;
+		this.type = ChannelType.GuildText;
+	}
+
+	/**
+	 * Returns a string that represents the Channel object as a mention.
+	 * @returns A string that represents the Channel object as a mention.
+	 * @example interaction.reply(`You chose ${interaction.channel}`); // => You chose #general
+	 */
+	public override toString() {
+		return `<#${this.id}>`;
+	}
+}

--- a/packages/framework/src/structs/GuildVoiceChannel.ts
+++ b/packages/framework/src/structs/GuildVoiceChannel.ts
@@ -1,0 +1,36 @@
+import { APIGuildChannel, ChannelType, Snowflake } from 'discord-api-types/v10';
+import type { App } from '../client';
+import { BaseChannel } from './BaseChannel';
+
+export class GuildVoiceChannel extends BaseChannel {
+	/**
+	 * The ID of the guild.
+	 */
+	public guildId!: Snowflake;
+
+	/**
+	 * The name of the channel.
+	 */
+	public name!: string;
+
+	/**
+	 * The type of the channel.
+	 */
+	public declare type: ChannelType.GuildVoice;
+
+	public constructor(app: App, raw: APIGuildChannel<ChannelType.GuildVoice>) {
+		super(app, raw);
+		this.guildId = raw.guild_id!;
+		this.name = raw.name!;
+		this.type = ChannelType.GuildVoice;
+	}
+
+	/**
+	 * Returns a string that represents the Channel object as a mention.
+	 * @returns A string that represents the Channel object as a mention.
+	 * @example interaction.reply(`You chose ${interaction.channel}`); // => You chose 🔊OnlyFriends
+	 */
+	public override toString() {
+		return `<#${this.id}>`;
+	}
+}

--- a/packages/framework/src/structs/ToBeFetched.ts
+++ b/packages/framework/src/structs/ToBeFetched.ts
@@ -1,0 +1,13 @@
+import type { NonRuntimeClass, StructureConstructor } from '../types';
+import type { Base } from './Base';
+
+export class ToBeFetched<T extends Base> {
+	public constructor(private base: Base, private object: NonRuntimeClass<T>, private _fetch: () => Promise<unknown>) {}
+
+	public async fetch(): Promise<T> {
+		const raw = await this._fetch();
+		const Structure = this.object as unknown as StructureConstructor<T>;
+
+		return new Structure(this.base.app, raw);
+	}
+}

--- a/packages/framework/src/structs/ToBeFetched.ts
+++ b/packages/framework/src/structs/ToBeFetched.ts
@@ -1,13 +1,14 @@
+import type { App } from '../client/App';
 import type { NonRuntimeClass, StructureConstructor } from '../types';
 import type { Base } from './Base';
 
 export class ToBeFetched<T extends Base> {
-	public constructor(private base: Base, private object: NonRuntimeClass<T>, private _fetch: () => Promise<unknown>) {}
+	public constructor(private app: App, private object: NonRuntimeClass<T>, private _fetch: () => Promise<unknown>) {}
 
 	public async fetch(): Promise<T> {
 		const raw = await this._fetch();
 		const Structure = this.object as unknown as StructureConstructor<T>;
 
-		return new Structure(this.base.app, raw);
+		return new Structure(this.app, raw);
 	}
 }

--- a/packages/framework/src/structs/managers/ChannelManager.ts
+++ b/packages/framework/src/structs/managers/ChannelManager.ts
@@ -1,0 +1,25 @@
+import { ChannelType, RESTGetAPIChannelResult, Routes } from 'discord-api-types/v10';
+import type { App } from '../../client';
+import type { DiscordChannel } from '../../types';
+import { Base } from '../Base';
+import { GuildTextChannel } from '../GuildTextChannel';
+import { GuildVoiceChannel } from '../GuildVoiceChannel';
+
+export class ChannelManager extends Base {
+	public constructor(app: App) {
+		super(app);
+	}
+
+	public async fetch(id: string): Promise<DiscordChannel> {
+		const raw = await this.app.rest.get<RESTGetAPIChannelResult>(Routes.channel(id));
+
+		switch (raw.type) {
+			case ChannelType.GuildText:
+				return new GuildTextChannel(this.app, raw);
+			case ChannelType.GuildVoice:
+				return new GuildVoiceChannel(this.app, raw);
+			default:
+				throw new Error(`Unknown channel type: ${raw.type}`);
+		}
+	}
+}

--- a/packages/framework/src/structs/managers/ChannelManager.ts
+++ b/packages/framework/src/structs/managers/ChannelManager.ts
@@ -6,12 +6,24 @@ import { GuildTextChannel } from '../GuildTextChannel';
 import { GuildVoiceChannel } from '../GuildVoiceChannel';
 
 export class ChannelManager extends Base {
-	public constructor(app: App) {
+	private guildId?: string;
+
+	/**
+	 * A manager for fetching channels.
+	 * @param app
+	 * @param guildId The ID of the guild to lock the manager to.
+	 */
+	public constructor(app: App, guildId?: string) {
 		super(app);
+		this.guildId = guildId;
 	}
 
 	public async fetch(id: string): Promise<DiscordChannel> {
 		const raw = await this.app.rest.get<RESTGetAPIChannelResult>(Routes.channel(id));
+
+		if ('guild_id' in raw && raw.guild_id !== this.guildId) {
+			throw new Error(`Channel is not in the guild (${this.guildId})`);
+		}
 
 		switch (raw.type) {
 			case ChannelType.GuildText:

--- a/packages/framework/src/structs/managers/index.ts
+++ b/packages/framework/src/structs/managers/index.ts
@@ -1,1 +1,2 @@
+export * from './ChannelManager';
 export * from './StructureManager';

--- a/packages/framework/src/types/DiscordChannel.ts
+++ b/packages/framework/src/types/DiscordChannel.ts
@@ -1,0 +1,4 @@
+import type { GuildTextChannel } from '../structs/GuildTextChannel';
+import type { GuildVoiceChannel } from '../structs/GuildVoiceChannel';
+
+export type DiscordChannel = GuildTextChannel | GuildVoiceChannel;

--- a/packages/framework/src/types/index.ts
+++ b/packages/framework/src/types/index.ts
@@ -1,2 +1,3 @@
+export * from './DiscordChannel';
 export * from './NonRuntimeClass';
 export * from './StructureConstructor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,6 +4057,11 @@ discord-api-types@^0.37.14:
   resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.14.tgz"
   integrity sha512-byBH7SfDCMJwxdqeS8k5sihltH88/YPhuwx+vF2cftSxFLdxyHyU/ZxDL3bq+LB2c4ls/TymE76/ISlLfniUXg==
 
+discord-api-types@^0.37.16:
+  version "0.37.16"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.16.tgz#3cc5fb56d34d12f57f20f81708ac0963b24c3e96"
+  integrity sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg==
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"


### PR DESCRIPTION
This fixes the nullable user on the GuildMember structure, an `APIGuildMember` will always send the user object except if it's sent from `MESSAGE_CREATE` or `MESSAGE_UPDATE` gateway events.