### PR TITLE
refactor(cli): .env resolving

### DIFF
--- a/packages/disploy/cli/src/commands/common/build.ts
+++ b/packages/disploy/cli/src/commands/common/build.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 import { Compile } from '../../lib/compiler';
 import type { DisployConfig } from '../../lib/disployConf';
 import { ProjectTools } from '../../lib/ProjectTools';
+
 export async function BuildApp({
 	skipPrebuild = false,
 	overrideTarget,

--- a/packages/disploy/cli/src/commands/dev.ts
+++ b/packages/disploy/cli/src/commands/dev.ts
@@ -26,9 +26,7 @@ export const DevCommand: CommandModule = {
 			cwd: process.cwd(),
 		});
 
-		const { clientId, publicKey, token } = await ProjectTools.resolveEnvironment({
-			cwd: process.cwd(),
-		});
+		const { clientId, publicKey, token } = await ProjectTools.resolveEnvironment();
 
 		const watcher = watch(root, { recursive: true });
 		let timeout: NodeJS.Timeout | null = null;

--- a/packages/disploy/cli/src/commands/sync.ts
+++ b/packages/disploy/cli/src/commands/sync.ts
@@ -16,9 +16,7 @@ export const SyncCommand: CommandModule = {
 	builder,
 	command: 'sync',
 	async handler() {
-		const { clientId, publicKey, token } = await ProjectTools.resolveEnvironment({
-			cwd: process.cwd(),
-		});
+		const { clientId, publicKey, token } = await ProjectTools.resolveEnvironment();
 
 		const input = await inquirer.prompt([
 			{

--- a/packages/disploy/cli/src/disploy.ts
+++ b/packages/disploy/cli/src/disploy.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import dotenv from 'dotenv';
+import path from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { BuildCommand } from './commands/build';
@@ -7,12 +9,25 @@ import { DeployCommand } from './commands/deploy';
 import { DevCommand } from './commands/dev';
 import { SyncCommand } from './commands/sync';
 
-const commands = [SyncCommand, DevCommand, BuildCommand, DeployCommand];
+(async () => {
+	const commands = [SyncCommand, DevCommand, BuildCommand, DeployCommand];
 
-const handler = yargs(hideBin(process.argv));
+	const handler = yargs(hideBin(process.argv));
 
-commands.forEach((command) => {
-	handler.command(command);
-});
+	commands.forEach((command) => {
+		handler.command(command);
+	});
 
-handler.demandCommand(1).parse();
+	handler.demandCommand(1).parse();
+
+	const globalOptions = await handler.options({
+		envFile: {
+			type: 'string',
+			alias: 'e',
+			description: 'Path to the .env file to use',
+			default: path.join(process.cwd(), '.env'),
+		},
+	}).argv;
+
+	dotenv.config({ path: globalOptions.envFile });
+})();

--- a/packages/disploy/cli/src/lib/ProjectTools.ts
+++ b/packages/disploy/cli/src/lib/ProjectTools.ts
@@ -1,5 +1,3 @@
-import dotenv from 'dotenv';
-import * as fs from 'node:fs/promises';
 import { DisployConfig, readConfig } from './disployConf';
 import { UserError } from './UserError';
 let config: DisployConfig | undefined;
@@ -13,25 +11,9 @@ async function resolveProject({ cwd }: { cwd: string }) {
 	return config;
 }
 
-async function findClosestEnv(opts: { cwd: string }) {
-	let cwd = opts.cwd;
+export type EnvironmentKey = 'token' | 'publicKey' | 'clientId';
 
-	while (cwd !== '/') {
-		const envPath = `${cwd}/.env`;
-		try {
-			await fs.access(envPath);
-			return envPath;
-		} catch (e) {
-			cwd = cwd.substring(0, cwd.lastIndexOf('/'));
-		}
-	}
-
-	return undefined;
-}
-
-async function resolveEnvironment({ cwd }: { cwd: string }) {
-	dotenv.config({ path: await findClosestEnv({ cwd }) });
-
+async function resolveEnvironment() {
 	const { DISCORD_TOKEN: token, DISCORD_PUBLIC_KEY: publicKey, DISCORD_CLIENT_ID: clientId } = process.env;
 
 	if (!token || !publicKey || !clientId) {


### PR DESCRIPTION
Instead of recursively going up directories until we find a `.env` file, we default to look for one in the CWD or take a `--envFile`/`-e` flag that points to one.