### PR TITLE
fix(cli): remove fetch warnings

### DIFF
--- a/packages/disploy/cli/src/disploy.ts
+++ b/packages/disploy/cli/src/disploy.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node  --no-warnings
 
 import dotenv from 'dotenv';
 import path from 'node:path';


### PR DESCRIPTION
This pull request suppresses all Node.js warnings when the Disploy CLI is executed.