### PR TITLE
feat(docs): framework-less guide

### DIFF
--- a/apps/docs/docs/Reference/framework-less/creating-commands.md
+++ b/apps/docs/docs/Reference/framework-less/creating-commands.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import Tabs from '@theme/Tabs';

--- a/apps/docs/docs/Reference/framework-less/creating-commands.md
+++ b/apps/docs/docs/Reference/framework-less/creating-commands.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Creating commands
+
+In the previous page, we mentioned importing `commands` from `./commands/commands.mjs` and recursively loading them. In this page, we'll go over how to actually create that file.
+
+## Creating the file
+
+First, we'll create the file. We'll call it `commands.mjs` and put it in a folder called `commands`.
+
+```bash
+mkdir commands
+touch commands/commands.mjs
+```
+
+```js
+// commands/commands.mjs
+import Ping from './core/ping.mjs';
+
+export default [Ping];
+```
+
+This file is the entry point for all of our commands. It's where we'll import all of our commands and export them as an array.
+
+## Creating the command
+
+Now, we'll create the command. We'll call it `ping` and put it in a folder called `core`.
+
+```bash
+mkdir commands/core
+touch commands/core/ping.mjs
+```
+
+```js
+export default {
+	name: 'ping',
+	description: 'Ping the bot',
+
+	run(interaction: ChatInputInteraction) {
+		interaction.reply({
+			content: 'Pong!',
+		});
+	},
+};
+```
+
+This is the command itself. It's a simple ping command that replies with `Pong!` when you run it.

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -44,11 +44,9 @@ We start by importing the `App` class from Disploy. We also import the `loadEnv`
 <TabItem value="Deno" label="Deno">
 
 ```js
-const { clientId, token, publicKey } = {
-	clientId: Deno.env.get('DISCORD_CLIENT_ID'),
-	token: Deno.env.get('DISCORD_TOKEN'),
-	publicKey: Deno.env.get('DISCORD_PUBLIC_KEY'),
-};
+const clientId = Deno.env.get('DISCORD_CLIENT_ID');
+const token = Deno.env.get('DISCORD_TOKEN');
+const publicKey = Deno.env.get('DISCORD_PUBLIC_KEY');
 ```
 
 </TabItem>

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -87,7 +87,13 @@ app.start({
 
 We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.
 
-```js
+```js {7-9}
+export const app = new App({
+	logger: {
+		debug: true,
+	},
+});
+
 for (const command of commands) {
 	app.commands.registerCommand(command);
 }

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 import Tabs from '@theme/Tabs';
@@ -88,4 +88,3 @@ for (const command of commands) {
 	app.commands.registerCommand(command);
 }
 ```
-

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -1,0 +1,104 @@
+---
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Creating the main file
+
+Firstly open your code editor and create a new file called `main.mjs` in a folder named "src" of your project. This is where we'll be writing our bot's code.
+
+<Tabs>
+
+<TabItem value="Deno" label="Deno">
+
+```js
+import { App } from 'disploy';
+import { config as loadEnv } from 'std/dotenv/mod.ts';
+import commands from './commands/commands.mjs';
+
+await loadEnv({
+	export: true,
+});
+```
+
+</TabItem>
+
+<TabItem value="Node" label="Node">
+
+```js
+import 'dotenv/config';
+import { App } from 'disploy';
+import commands from './commands/commands.mjs';
+```
+
+</TabItem>
+
+</Tabs>
+
+We start by importing the `App` class from Disploy. We also import the `loadEnv` function from `std/dotenv/mod.ts` (Deno) or `dotenv` (Node.js). This function will load our environment variables from a `.env` file.
+
+<Tabs>
+
+<TabItem value="Deno" label="Deno">
+
+```js
+const { clientId, token, publicKey } = {
+	clientId: Deno.env.get('DISCORD_CLIENT_ID'),
+	token: Deno.env.get('DISCORD_TOKEN'),
+	publicKey: Deno.env.get('DISCORD_PUBLIC_KEY'),
+};
+```
+
+</TabItem>
+
+<TabItem value="Node" label="Node">
+
+```js
+const { clientId, token, publicKey } = {
+	clientId: process.env.DISCORD_CLIENT_ID,
+	token: process.env.DISCORD_TOKEN,
+	publicKey: process.env.DISCORD_PUBLIC_KEY,
+};
+```
+
+</TabItem>
+
+</Tabs>
+
+We then create a new instance of the `App` class and export it so we can use it in other files. We then call the `start` method on the `app` instance and pass in our client ID, token and public key.
+
+```js
+if (!clientId || !token || !publicKey) {
+	throw new Error('Missing environment variables');
+}
+```
+
+We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.
+
+```js
+export const app = new App({
+	logger: {
+		debug: true,
+	},
+});
+
+app.start({
+	clientId,
+	token,
+	publicKey,
+});
+
+for (const command of commands) {
+	app.commands.registerCommand(command);
+}
+```
+
+## Breaking down the code
+
+We start by importing the `App` class from Disploy. We also import the `loadEnv` function from `std/dotenv/mod.ts` (Deno) or `dotenv` (Node.js). This function will load our environment variables from a `.env` file.
+
+We then create a new instance of the `App` class and export it so we can use it in other files. We then call the `start` method on the `app` instance and pass in our client ID, token and public key.
+
+We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -89,10 +89,3 @@ for (const command of commands) {
 }
 ```
 
-## Breaking down the code
-
-We start by importing the `App` class from Disploy. We also import the `loadEnv` function from `std/dotenv/mod.ts` (Deno) or `dotenv` (Node.js). This function will load our environment variables from a `.env` file.
-
-We then create a new instance of the `App` class and export it so we can use it in other files. We then call the `start` method on the `app` instance and pass in our client ID, token and public key.
-
-We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -61,15 +61,13 @@ const { clientId, token, publicKey } = process.env;
 
 </Tabs>
 
-We then create a new instance of the `App` class and export it so we can use it in other files. We then call the `start` method on the `app` instance and pass in our client ID, token and public key.
-
 ```js
 if (!clientId || !token || !publicKey) {
 	throw new Error('Missing environment variables');
 }
 ```
 
-We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.
+We then create a new instance of the `App` class and export it so we can use it in other files. We then call the `start` method on the `app` instance and pass in our client ID, token and public key.
 
 ```js
 export const app = new App({
@@ -83,7 +81,11 @@ app.start({
 	token,
 	publicKey,
 });
+```
 
+We then loop through our commands and register them with the `app.commands.registerCommand` method. We also set the `debug` option to `true` in the `logger` option of the `App` class. This helps us debug our bot.
+
+```js
 for (const command of commands) {
 	app.commands.registerCommand(command);
 }

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -54,7 +54,9 @@ const publicKey = Deno.env.get('DISCORD_PUBLIC_KEY');
 <TabItem value="Node" label="Node">
 
 ```js
-const { clientId, token, publicKey } = process.env;
+const clientId = process.env.DISCORD_CLIENT_ID;
+const token = process.env.DISCORD_TOKEN;
+const publicKey = process.env.DISCORD_PUBLIC_KEY;
 ```
 
 </TabItem>

--- a/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
+++ b/apps/docs/docs/Reference/framework-less/creating-main-file.mdx
@@ -54,11 +54,7 @@ const publicKey = Deno.env.get('DISCORD_PUBLIC_KEY');
 <TabItem value="Node" label="Node">
 
 ```js
-const { clientId, token, publicKey } = {
-	clientId: process.env.DISCORD_CLIENT_ID,
-	token: process.env.DISCORD_TOKEN,
-	publicKey: process.env.DISCORD_PUBLIC_KEY,
-};
+const { clientId, token, publicKey } = process.env;
 ```
 
 </TabItem>

--- a/apps/docs/docs/Reference/framework-less/deploying-commands.md
+++ b/apps/docs/docs/Reference/framework-less/deploying-commands.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 import Tabs from '@theme/Tabs';

--- a/apps/docs/docs/Reference/framework-less/deploying-commands.md
+++ b/apps/docs/docs/Reference/framework-less/deploying-commands.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Deploying commands
+
+We can call `syncCommands` on our `CommandManager` attached to our `App` instance to deploy our commands to Discord.
+
+```ts
+import { app } from './main.mjs';
+
+console.log(`Deploying ${app.commands.getCommands().size} commands...`);
+
+app.commands.syncCommands(false); // false = replace existing commands deployed to Discord
+
+console.log('Deployed!');
+```

--- a/apps/docs/docs/Reference/framework-less/deploying-commands.md
+++ b/apps/docs/docs/Reference/framework-less/deploying-commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 We can call `syncCommands` on our `CommandManager` attached to our `App` instance to deploy our commands to Discord.
 
-```ts
+```js
 import { app } from './main.mjs';
 
 console.log(`Deploying ${app.commands.getCommands().size} commands...`);

--- a/apps/docs/docs/Reference/framework-less/index.md
+++ b/apps/docs/docs/Reference/framework-less/index.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+---
+
+# Using Disploy without the CLI
+
+Using the Disploy CLI is completely optional, though reccomended. It's purpose is to bundle your bot into a single file that can be deployed to Cloudflare Workers or imported into your own project. If you don't want to use the CLI, you can still use Disploy, but you'll have to bundle your bot yourself.
+
+:::tip
+
+Think of it like this:
+
+- Disploy is a library that you can use to build bots.
+- Disploy's CLI is a tool that turns Disploy into a framework, it takes in commands and bundles your bot into a single file that can be deployed to Cloudflare Workers or imported into your own project.
+
+:::

--- a/apps/docs/docs/Reference/framework-less/index.md
+++ b/apps/docs/docs/Reference/framework-less/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Using Disploy without the CLI
 
-Using the Disploy CLI is completely optional, though reccomended. It's purpose is to bundle your bot into a single file that can be deployed to Cloudflare Workers or imported into your own project. If you don't want to use the CLI, you can still use Disploy, but you'll have to bundle your bot yourself.
+Using the Disploy CLI is completely optional, though recommended. Its purpose is to bundle your bot into a single file that can be deployed to Cloudflare Workers or imported into your own project. If you don't want to use the CLI, you can still use Disploy, but you'll have to bundle your bot yourself.
 
 :::tip
 

--- a/apps/docs/docs/Reference/framework-less/prep-work.mdx
+++ b/apps/docs/docs/Reference/framework-less/prep-work.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 2
+---
+
+# Preparations
+
+:::info
+
+We expect you to already have a working installation of Deno 1.28+ or Node.js 18+
+
+:::
+
+## Setting up your project
+
+<Tabs>
+
+<TabItem value="Deno" label="Deno">
+
+Start by creating a `deno.json` file in your project directory:
+
+```json
+{
+	"importMap": "import_map.json"
+}
+```
+
+Then create an `import_map.json` file in the same directory:
+
+```json
+{
+	"imports": {
+		"disploy": "npm:disploy@dev",
+		"std/": "https://deno.land/std@0.164.0/",
+		"fmt/": "https://deno.land/std@0.164.0/fmt/"
+	}
+}
+```
+
+This will allow you to import Disploy from the `disploy` module.
+We are also importing the standard library from Deno's official repository.
+
+</TabItem>
+
+<TabItem value="Node" label="Node">
+
+You can initialize a Node.js project with the following command:
+
+```bash
+npm init -y
+# or
+yarn init -y
+# or
+pnpm init -y
+```
+
+Then install Disploy, dotenv and express since we will be using them in this guide:
+
+```bash
+npm install disploy dotenv express
+# or
+yarn add disploy dotenv express
+# or
+pnpm add disploy dotenv express
+```
+
+</TabItem>
+
+</Tabs>

--- a/apps/docs/docs/Reference/framework-less/prep-work.mdx
+++ b/apps/docs/docs/Reference/framework-less/prep-work.mdx
@@ -12,6 +12,8 @@ We expect you to already have a working installation of Deno 1.28+ or Node.js 18
 
 ## Setting up your project
 
+### Dependencies
+
 <Tabs>
 
 <TabItem value="Deno" label="Deno">
@@ -66,3 +68,18 @@ pnpm add disploy dotenv express
 </TabItem>
 
 </Tabs>
+
+### Creating a `.env`
+
+Create a `.env` file in your project directory and add the following content:
+
+```env
+DISCORD_CLIENT_ID="Your Discord bot's client id"
+DISCORD_TOKEN="Your Discord bot's token"
+DISCORD_PUBLIC_KEY="Your Discord's bot's public key"
+```
+
+You can find all of these values in your [Discord Developer Portal](https://discord.com/developers/applications).
+
+![Public Key and Client ID](https://cdn.discordapp.com/attachments/1038456602610651196/1042198788653195306/Screenshot_2022-11-16_at_9.05.23_am.png)
+![Bot Token](https://cdn.discordapp.com/attachments/1038456602610651196/1042198948938530977/Screenshot_2022-11-16_at_9.06.01_am.png)

--- a/apps/docs/docs/Reference/framework-less/starting.mdx
+++ b/apps/docs/docs/Reference/framework-less/starting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 import Tabs from '@theme/Tabs';

--- a/apps/docs/docs/Reference/framework-less/starting.mdx
+++ b/apps/docs/docs/Reference/framework-less/starting.mdx
@@ -199,3 +199,5 @@ Once ngrok is running, you should do the following:
 
 1. Visit https://discord.com/developers/applications/your_bot_id/information
 2. Set INTERACTIONS ENDPOINT URL to https://xxxx-xx-xxx-xxx-xx.ngrok.io/interactions
+
+![Setting the interactions endpoint URL](https://cdn.discordapp.com/attachments/1038456602610651196/1042195337458241657/Screenshot_2022-11-16_at_8.51.05_am.png)

--- a/apps/docs/docs/Reference/framework-less/starting.mdx
+++ b/apps/docs/docs/Reference/framework-less/starting.mdx
@@ -20,45 +20,58 @@ Our goal is to transform whatever request type we receive from our implementatio
 import { serve } from 'https://deno.land/std@0.155.0/http/server.ts';
 import { app } from './main.mjs';
 
+// The handler function will be called every time a request is made to our server
 const handler = async (req) => {
+	// Ignore any requests that aren't POST
 	if (req.method !== 'POST') {
 		return new Response('Method not allowed', { status: 405 });
 	}
 
-	const randId = Math.random().toString(36).substring(7);
-
+	// Loop over headers and transform them to a record
 	const reqHeaders = {};
 	for (const [key, value] of req.headers) {
 		reqHeaders[key] = value;
 	}
+
+	// Create a TRequest object
 	const tReq = {
 		body: await req.json(),
 		headers: reqHeaders,
 		_request: req,
-		randId,
 	};
 
+	// Handle the request using Disploy's router
 	const payload = await app.router.entry(tReq);
 	const { status, headers, body } = payload.serialized;
+
+	// Create a Response object to return to Discord
 	return new Response(JSON.stringify(body), {
+		// Set the HTTP status code
 		status,
+		// Set the HTTP headers
 		headers: (() => {
+			// Create an object to hold the headers
 			const headersObj = {
 				'content-type': 'application/json',
 			};
+			// Loop over the headers passed in as an argument
 			for (const [key, value] of Object.entries(headers)) {
+				// If the value is a string, add it to the headers object
 				if (typeof value === 'string') {
 					headersObj[key] = value;
 				}
+				// If the value is an array, join the array into a string with commas between each element
 				if (Array.isArray(value)) {
 					headersObj[key] = value.join(',');
 				}
 			}
+			// Return the headers object
 			return headersObj;
 		})(),
 	});
 };
 
+// Create a server
 serve(handler);
 ```
 
@@ -107,22 +120,30 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import { app } from './main.mjs';
 
+// Create an Express app
 const server = express();
+
+// Enable JSON body parsing
 server.use(bodyParser.json());
 
+// Create a route for our bot
 server.post('/interactions', async (req, res) => {
+	// Create a TRequest object
 	const tReq: TRequest = {
 		body: req.body,
 		headers: req.headers,
 		_request: req,
 	};
 
+	// Handle the request using Disploy's router
 	const payload = await app.router.entry(tReq);
 	const { status, headers, body } = payload.serialized;
 
+	// Return the response to Discord
 	return void res.status(status).set(headers).send(body);
 });
 
+// Start the server
 server.listen(8000);
 ```
 

--- a/apps/docs/docs/Reference/framework-less/starting.mdx
+++ b/apps/docs/docs/Reference/framework-less/starting.mdx
@@ -1,0 +1,123 @@
+---
+sidebar_position: 5
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Starting our bot
+
+The `Router` class attached to our `App` instance is the main entry point for our bot. It is responsible for handling all incoming interactions and dispatching them to the appropriate handlers. We will be using the `Router` class to be an entry point for our bot.
+
+Our goal is to transform whatever request type we receive from our implementation of a web server to a `TRequest` object. This object will be passed to the `Router` class to be handled and will fulfill a Promise that we will return to our web server.
+
+<Tabs>
+
+<TabItem value="Deno" label="Deno">
+
+```js
+// src/server.mjs
+import { serve } from 'https://deno.land/std@0.155.0/http/server.ts';
+import { app } from './main.mjs';
+
+const handler = async (req) => {
+	if (req.method !== 'POST') {
+		return new Response('Method not allowed', { status: 405 });
+	}
+
+	const randId = Math.random().toString(36).substring(7);
+
+	const reqHeaders = {};
+	for (const [key, value] of req.headers) {
+		reqHeaders[key] = value;
+	}
+	const tReq = {
+		body: await req.json(),
+		headers: reqHeaders,
+		_request: req,
+		randId,
+	};
+
+	const payload = await app.router.entry(tReq);
+	const { status, headers, body } = payload.serialized;
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: (() => {
+			const headersObj = {
+				'content-type': 'application/json',
+			};
+			for (const [key, value] of Object.entries(headers)) {
+				if (typeof value === 'string') {
+					headersObj[key] = value;
+				}
+				if (Array.isArray(value)) {
+					headersObj[key] = value.join(',');
+				}
+			}
+			return headersObj;
+		})(),
+	});
+};
+
+serve(handler);
+```
+
+We can now run our bot by running the following command:
+
+```bash
+deno run --allow-read --allow-env --allow-net src/server.mjs
+```
+
+</TabItem>
+
+<TabItem value="Node" label="Node">
+
+```js
+// src/server.mjs
+import bodyParser from 'body-parser';
+import express from 'express';
+import { app } from './main.mjs';
+
+const server = express();
+server.use(bodyParser.json());
+
+server.post('/interactions', async (req, res) => {
+	const tReq: TRequest = {
+		body: req.body,
+		headers: req.headers,
+		_request: req,
+	};
+
+	const payload = await app.router.entry(tReq);
+	const { status, headers, body } = payload.serialized;
+
+	return void res.status(status).set(headers).send(body);
+});
+
+server.listen(8000);
+```
+
+We can now run our bot by running the following command:
+
+```bash
+node src/server.js
+```
+
+</TabItem>
+
+</Tabs>
+
+## Exposing our bot to the internet
+
+Now that we have our bot running, we need to expose it to the internet. We will be using [ngrok](https://ngrok.com/) to do this. You can download it from [here](https://ngrok.com/download).
+
+Once you have downloaded ngrok, you can run the following command to expose your bot to the internet:
+
+```bash
+ngrok http 8000
+```
+
+Once ngrok is running, you should do the following:
+
+1. Visit https://discord.com/developers/applications/your_bot_id/information
+2. Set INTERACTIONS ENDPOINT URL to https://xxxx-xx-xxx-xxx-xx.ngrok.io/interactions

--- a/apps/docs/docs/Reference/framework-less/starting.mdx
+++ b/apps/docs/docs/Reference/framework-less/starting.mdx
@@ -68,6 +68,35 @@ We can now run our bot by running the following command:
 deno run --allow-read --allow-env --allow-net src/server.mjs
 ```
 
+<details>
+  <summary> Using <code>deno.json</code> tasks </summary>
+
+```json {4-7}
+{
+	{
+	"importMap": "import_map.json",
+	"tasks": {
+		"start": "deno run --allow-read --allow-env --allow-net src/server.mjs",
+		"deploy": "deno run --allow-read --allow-env src/deploy.mjs"
+		}
+	}
+}
+```
+
+You can now run your bot by running the following command:
+
+```bash
+deno task start
+```
+
+Or to deploy commands:
+
+```bash
+deno task deploy
+```
+
+</details>
+
 </TabItem>
 
 <TabItem value="Node" label="Node">
@@ -102,6 +131,34 @@ We can now run our bot by running the following command:
 ```bash
 node src/server.js
 ```
+
+<details>
+  <summary> Using <code>package.json</code> scripts </summary>
+
+```json {3-6}
+{
+	...
+	"scripts": {
+		"start": "node src/server.mjs",
+		"deploy": "node src/deploy.mjs"
+	}
+	...
+}
+```
+
+You can now run your bot by running the following command:
+
+```bash
+npm run start
+```
+
+Or to deploy commands:
+
+```bash
+npm run deploy
+```
+
+</details>
 
 </TabItem>
 


### PR DESCRIPTION
Implements a guide on how to use Disploy with Deno and Node.js without the framework supplied from the CLI.