### PR TITLE
feat(cli): watcher

### DIFF
--- a/apps/example/disploy.json
+++ b/apps/example/disploy.json
@@ -1,5 +1,6 @@
 {
 	"prebuild": "yarn run build",
+	"watcher": "touch hello-world",
 	"root": "dist",
 	"target": {
 		"type": "cloudflare",

--- a/apps/example/disploy.json
+++ b/apps/example/disploy.json
@@ -1,6 +1,6 @@
 {
 	"prebuild": "yarn run build",
-	"watcher": "touch hello-world",
+	"watcher": "yarn run dev",
 	"root": "dist",
 	"target": {
 		"type": "cloudflare",

--- a/packages/disploy/cli/src/commands/common/build.ts
+++ b/packages/disploy/cli/src/commands/common/build.ts
@@ -1,9 +1,9 @@
-import { spawn } from 'child_process';
 import * as color from 'colorette';
 import ora from 'ora';
 import { Compile } from '../../lib/compiler';
 import type { DisployConfig } from '../../lib/disployConf';
 import { ProjectTools } from '../../lib/ProjectTools';
+import { runShellCommand } from '../../lib/shell';
 
 export async function BuildApp({
 	skipPrebuild = false,
@@ -26,18 +26,7 @@ export async function BuildApp({
 
 	if (prebuild && !skipPrebuild) {
 		spinner = ora('Running prebuild script').start();
-		await new Promise<void>((resolve, reject) => {
-			spawn(prebuild.split(' ')[0]!, prebuild.split(' ').slice(1), {
-				cwd: process.cwd(),
-				stdio: 'ignore',
-			}).on('exit', (code) => {
-				if (code === 0) {
-					resolve();
-				} else {
-					reject();
-				}
-			});
-		});
+		await runShellCommand(prebuild);
 		spinner.succeed();
 	}
 

--- a/packages/disploy/cli/src/commands/dev.ts
+++ b/packages/disploy/cli/src/commands/dev.ts
@@ -6,6 +6,7 @@ import ora from 'ora';
 import type { Argv, CommandModule } from 'yargs';
 import { createServer, setApp } from '../lib/devServer';
 import { ProjectTools } from '../lib/ProjectTools';
+import { runShellCommand } from '../lib/shell';
 import { F } from '../lib/StringFormatters';
 import { logger } from '../utils/logger';
 import { BuildApp } from './common/build';
@@ -22,9 +23,21 @@ export const DevCommand: CommandModule = {
 	async handler() {
 		const devServerPort = 5002;
 
-		const { root } = await ProjectTools.resolveProject({
+		const {
+			root,
+			prebuild,
+			watcher: devScript,
+		} = await ProjectTools.resolveProject({
 			cwd: process.cwd(),
 		});
+
+		if (prebuild) {
+			await runShellCommand(prebuild);
+		}
+
+		if (devScript) {
+			runShellCommand(devScript);
+		}
 
 		const { clientId, publicKey, token } = await ProjectTools.resolveEnvironment();
 

--- a/packages/disploy/cli/src/disploy.ts
+++ b/packages/disploy/cli/src/disploy.ts
@@ -2,13 +2,19 @@
 
 import dotenv from 'dotenv';
 import path from 'node:path';
-import yargs from 'yargs';
+import yargs, { CommandModule } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { BuildCommand } from './commands/build';
 import { DeployCommand } from './commands/deploy';
 import { DevCommand } from './commands/dev';
 import { SyncCommand } from './commands/sync';
 import { TestServerCommand } from './commands/test-server';
+
+const cleanExit = function () {
+	process.exit();
+};
+process.on('SIGINT', cleanExit);
+process.on('SIGTERM', cleanExit);
 
 (async () => {
 	const commands = [SyncCommand, DevCommand, BuildCommand, DeployCommand, TestServerCommand];
@@ -27,7 +33,7 @@ import { TestServerCommand } from './commands/test-server';
 	dotenv.config({ path: globalOptions.envFile });
 
 	commands.forEach((command) => {
-		handler.command(command);
+		handler.command(command as CommandModule);
 	});
 
 	handler.demandCommand(1).parse();

--- a/packages/disploy/cli/src/lib/disployConf/index.ts
+++ b/packages/disploy/cli/src/lib/disployConf/index.ts
@@ -5,6 +5,7 @@ import { UserError } from '../UserError';
 
 const disployConfigSchema = z.object({
 	prebuild: z.string().optional(),
+	watcher: z.string().optional(),
 	root: z.string(),
 	target: z.union([
 		z.object({

--- a/packages/disploy/cli/src/lib/shell.ts
+++ b/packages/disploy/cli/src/lib/shell.ts
@@ -1,10 +1,10 @@
-import { spawn } from 'node:child_process';
+import { spawn, StdioOptions } from 'node:child_process';
 
-export async function runShellCommand(c: string) {
+export async function runShellCommand(c: string, stdioMode: StdioOptions = 'ignore') {
 	await new Promise<void>((resolve, reject) => {
 		spawn(c.split(' ')[0]!, c.split(' ').slice(1), {
 			cwd: process.cwd(),
-			stdio: 'ignore',
+			stdio: stdioMode,
 		}).on('exit', (code) => {
 			if (code === 0) {
 				resolve();

--- a/packages/disploy/cli/src/lib/shell.ts
+++ b/packages/disploy/cli/src/lib/shell.ts
@@ -1,0 +1,16 @@
+import { spawn } from 'node:child_process';
+
+export async function runShellCommand(c: string) {
+	await new Promise<void>((resolve, reject) => {
+		spawn(c.split(' ')[0]!, c.split(' ').slice(1), {
+			cwd: process.cwd(),
+			stdio: 'ignore',
+		}).on('exit', (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject();
+			}
+		});
+	});
+}


### PR DESCRIPTION
Implements a `watcher` property so the user doesn't have to run their preferred typescript toolchain in the background while using `disploy dev`.