### PR TITLE
feat(structs): TBF id

### DIFF
--- a/packages/disploy/src/client/App.ts
+++ b/packages/disploy/src/client/App.ts
@@ -61,7 +61,7 @@ export class App {
 		this.channels = new ChannelManager(this);
 
 		// Misc
-		this.user = new ToBeFetched(this, User, () => this.rest.get(Routes.user(this.clientId)));
+		this.user = new ToBeFetched(this, User, this.clientId, (id) => this.rest.get(Routes.user(id)));
 
 		// Command Framework
 

--- a/packages/disploy/src/structs/BaseInteraction.ts
+++ b/packages/disploy/src/structs/BaseInteraction.ts
@@ -1,10 +1,9 @@
-import type { APIInteraction, Snowflake } from 'discord-api-types/v10';
+import { APIInteraction, Routes, Snowflake } from 'discord-api-types/v10';
 import type { App } from '../client';
 import { SnowflakeUtil } from '../utils';
 import { Base } from './Base';
 import { Guild } from './Guild';
 import { ToBeFetched } from './ToBeFetched';
-
 
 export class BaseInteraction extends Base {
 	/**
@@ -32,6 +31,8 @@ export class BaseInteraction extends Base {
 		this.id = raw.id;
 		this.token = raw.token;
 		this.createdTimestamp = SnowflakeUtil.toTimestamp(this.id);
-		this.guild = raw.guild_id ? new ToBeFetched(this.app, Guild, () => app.rest.get(`/guilds/${raw.guild_id}`)) : null;
+		this.guild = raw.guild_id
+			? new ToBeFetched(this.app, Guild, raw.guild_id, (id) => app.rest.get(Routes.guild(id)))
+			: null;
 	}
 }

--- a/packages/disploy/src/structs/Guild.ts
+++ b/packages/disploy/src/structs/Guild.ts
@@ -103,7 +103,7 @@ export class Guild extends Base {
 		this.name = raw.name;
 
 		this.afkChannel = raw.afk_channel_id
-			? new ToBeFetched(this.app, GuildVoiceChannel, () => this.app.rest.get(`/channels/${raw.afk_channel_id}`))
+			? new ToBeFetched(this.app, GuildVoiceChannel, raw.afk_channel_id, (id) => this.app.rest.get(Routes.channel(id)))
 			: null;
 		this.afkChannelId = raw.afk_channel_id;
 		this.afkTimeout = raw.afk_timeout;
@@ -135,6 +135,6 @@ export class Guild extends Base {
 	}
 
 	public async fetch(): Promise<this> {
-		return this.patch(await this.app.rest.get<APIGuild>(`/guilds/${this.id}?with_counts=true`));
+		return this.patch(await this.app.rest.get<APIGuild>(`${Routes.guild(this.id)}?with_counts=true`));
 	}
 }

--- a/packages/disploy/src/structs/ToBeFetched.ts
+++ b/packages/disploy/src/structs/ToBeFetched.ts
@@ -3,10 +3,18 @@ import type { NonRuntimeClass, StructureConstructor } from '../types';
 import type { Base } from './Base';
 
 export class ToBeFetched<T extends Base> {
-	public constructor(private app: App, private object: NonRuntimeClass<T>, private _fetch: () => Promise<unknown>) {}
+	public constructor(
+		private app: App,
+		private object: NonRuntimeClass<T>,
+		/**
+		 * The ID of the held object.
+		 */
+		public id: string,
+		private _fetch: (id: string) => Promise<unknown>,
+	) {}
 
 	public async fetch(): Promise<T> {
-		const raw = await this._fetch();
+		const raw = await this._fetch(this.id);
 		const Structure = this.object as unknown as StructureConstructor<T>;
 
 		return new Structure(this.app, raw);


### PR DESCRIPTION
Allows you to access the Snowflake of `ToBeFetched` objects without fetching it, and also fixes places where we don't consistently use `Routes.*` from discord-api-types.