### PR TITLE
chore(docs): fix typo in command example

### DIFF
--- a/apps/docs/docs/getting-started/cli-framework/prep-work/creating-a-new-project.md
+++ b/apps/docs/docs/getting-started/cli-framework/prep-work/creating-a-new-project.md
@@ -11,7 +11,7 @@ npx create-disploy-app@latest
 # or
 yarn create disploy-app
 # or
-pnpm create disploy-ap
+pnpm create disploy-app
 ```
 
 > Make sure to select "Disploy CLI Framework (TypeScript)".


### PR DESCRIPTION
Changes `disploy-ap` to `disploy-app`.